### PR TITLE
Add example channel interceptor plugin

### DIFF
--- a/channel-interceptor/README.md
+++ b/channel-interceptor/README.md
@@ -1,0 +1,30 @@
+# Open Channel Interceptor plugin
+
+This plugin provides an example of how to accept or reject OpenChannel messages received by the node. 
+
+Disclaimer: this plugin is for demonstration purposes only.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Build
+
+To build this plugin, run the following command in this directory:
+
+```sh
+mvn package
+```
+
+## Run
+
+To run eclair with this plugin, start eclair with the following command:
+
+```sh
+eclair-node-<version>/bin/eclair-node.sh <path-to-plugin-jar>/channel-interceptor-plugin-<version>.jar
+```
+
+## Commands
+
+```sh
+eclair-cli ??
+```
+

--- a/channel-interceptor/pom.xml
+++ b/channel-interceptor/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fr.acinq.eclair</groupId>
+        <artifactId>eclair-plugins_2.13</artifactId>
+        <version>0.8.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>channel-interceptor-plugin</artifactId>
+    <packaging>jar</packaging>
+    <name>channel-interceptor-plugin</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Main-Class>fr.acinq.eclair.plugins.channelinterceptor.ChannelInterceptorPlugin</Main-Class>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-core_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-node_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- TESTS -->
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-actor-testkit-typed_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-core_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/channel-interceptor/src/main/scala/fr/acinq/eclair/plugins/channelinterceptor/ChannelInterceptorPlugin.scala
+++ b/channel-interceptor/src/main/scala/fr/acinq/eclair/plugins/channelinterceptor/ChannelInterceptorPlugin.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.channelinterceptor
+
+import akka.actor.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.actor.typed.{ActorRef, SupervisorStrategy}
+import fr.acinq.eclair.InterceptedMessageType.InterceptOpenChannel
+import fr.acinq.eclair.{InterceptMessagePlugin, InterceptedMessageType, Kit, NodeParams, Plugin, PluginParams, Setup}
+import grizzled.slf4j.Logging
+
+/**
+ * Intercept OpenChannel messages received by the node and respond by continuing the process
+ * of accepting the request, potentially with different local parameters, or failing the request.
+ */
+
+class ChannelInterceptorPlugin extends Plugin with Logging {
+  var pluginKit: ChannelInterceptorKit = _
+
+  override def params: PluginParams = new InterceptMessagePlugin {
+    // @formatter:off
+    override def name: String = "ChannelInterceptorPlugin"
+    override def canIntercept: Set[InterceptedMessageType.Value] = Set(InterceptOpenChannel)
+    // @formatter:on
+  }
+
+  override def onSetup(setup: Setup): Unit = {
+  }
+
+  override def onKit(kit: Kit): Unit = {
+    val openChannelInterceptor = kit.system.spawn(Behaviors.supervise(OpenChannelInterceptor()).onFailure(SupervisorStrategy.restart), "open-channel-interceptor")
+    pluginKit = ChannelInterceptorKit(kit.nodeParams, kit.system, openChannelInterceptor)
+  }
+}
+
+case class ChannelInterceptorKit(nodeParams: NodeParams, system: ActorSystem, openChannelInterceptor: ActorRef[OpenChannelInterceptor.Command])

--- a/channel-interceptor/src/main/scala/fr/acinq/eclair/plugins/channelinterceptor/OpenChannelInterceptor.scala
+++ b/channel-interceptor/src/main/scala/fr/acinq/eclair/plugins/channelinterceptor/OpenChannelInterceptor.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.channelinterceptor
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.eventstream.EventStream
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import fr.acinq.eclair.channel.ChannelConfig
+import fr.acinq.eclair.io.OpenChannelReceived
+import fr.acinq.eclair.io.Peer.{OutgoingMessage, SpawnChannelNonInitiator}
+import fr.acinq.eclair.wire.protocol.{Error, OpenDualFundedChannel}
+
+/**
+ * Intercept OpenChannel and OpenDualFundedChannel messages received by the node. Respond to the peer
+ * that received the request with SpawnChannelNonInitiator to continue the open channel process,
+ * optionally with modified local parameters, or fail the request by responding to the initiator
+ * with an Error message.
+ */
+
+object OpenChannelInterceptor {
+
+  def apply(): Behavior[Command] = {
+    Behaviors.setup {
+      context => new OpenChannelInterceptor(context).start()
+    }
+  }
+
+  // @formatter:off
+  sealed trait Command
+  // @formatter:on
+
+  private case class WrappedOpenChannelReceived(openChannelReceived: OpenChannelReceived) extends Command
+
+}
+
+private class OpenChannelInterceptor(context: ActorContext[OpenChannelInterceptor.Command]) {
+
+  import OpenChannelInterceptor._
+
+  def start(): Behavior[Command] = {
+    context.system.eventStream ! EventStream.Subscribe(context.messageAdapter[OpenChannelReceived](WrappedOpenChannelReceived))
+
+    Behaviors.receiveMessage {
+      case WrappedOpenChannelReceived(wo) =>
+        wo.peer ! (wo.open match {
+          case Left(_) =>
+            // example: accept all single funded open channel requests
+            SpawnChannelNonInitiator(wo.open, ChannelConfig.standard, wo.channelType, wo.localParams)
+          case Right(o: OpenDualFundedChannel) =>
+            // example: fail all dual funded open channel requests
+            OutgoingMessage(Error(o.temporaryChannelId, "dual funded channel request rejected"), wo.connectionInfo.peerConnection)
+        })
+        Behaviors.same
+    }
+  }
+
+}

--- a/channel-interceptor/src/test/scala/fr/acinq/eclair/plugins/channelinterceptor/OpenChannelInterceptorSpec.scala
+++ b/channel-interceptor/src/test/scala/fr/acinq/eclair/plugins/channelinterceptor/OpenChannelInterceptorSpec.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.channelinterceptor
+
+import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
+import akka.actor.typed.eventstream.EventStream
+import akka.actor.typed.scaladsl.adapter.TypedActorRefOps
+import com.typesafe.config.ConfigFactory
+import fr.acinq.bitcoin.scalacompat.Crypto.PrivateKey
+import fr.acinq.bitcoin.scalacompat.{ByteVector32, Crypto, DeterministicWallet, SatoshiLong}
+import fr.acinq.eclair.TestConstants.{Alice, Bob}
+import fr.acinq.eclair.blockchain.fee.FeeratePerKw
+import fr.acinq.eclair.channel.{ChannelConfig, ChannelFlags, ChannelTypes, LocalParams}
+import fr.acinq.eclair.io.Peer.{OutgoingMessage, SpawnChannelNonInitiator}
+import fr.acinq.eclair.io.{ConnectionInfo, OpenChannelReceived}
+import fr.acinq.eclair.wire.protocol.{Init, NodeAddress, OpenChannel, OpenDualFundedChannel}
+import fr.acinq.eclair.{CltvExpiryDelta, Features, MilliSatoshiLong, UInt64, randomKey}
+import org.scalatest.funsuite.AnyFunSuiteLike
+import scodec.bits.ByteVector
+
+class OpenChannelInterceptorSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with AnyFunSuiteLike {
+
+  val publicKey: Crypto.PublicKey = PrivateKey(ByteVector32.One).publicKey
+
+  test("should intercept and respond to OpenChannelReceived events") {
+    val openChannel = OpenChannel(ByteVector32.Zeroes, ByteVector32.Zeroes, 0 sat, 0 msat, 1 sat, UInt64(1), 1 sat, 1 msat, FeeratePerKw(1 sat), CltvExpiryDelta(1), 1, publicKey, publicKey, publicKey, publicKey, publicKey, publicKey, ChannelFlags.Private)
+    val openDualChannel = OpenDualFundedChannel(ByteVector32.Zeroes, ByteVector32.One, FeeratePerKw(1 sat), FeeratePerKw(1 sat), 0 sat, 0 sat, UInt64(0), 0 msat, CltvExpiryDelta(155), 0, 0, publicKey, publicKey, publicKey, publicKey, publicKey, publicKey, ChannelFlags(true))
+    val localParams = LocalParams(randomKey().publicKey, DeterministicWallet.KeyPath(Seq(42L)), 1 sat, Long.MaxValue.msat, Some(500 sat), 1 msat, CltvExpiryDelta(144), 50, isInitiator = false, ByteVector.empty, None, Features.empty)
+
+    testKit.spawn(OpenChannelInterceptor())
+    val peerProbe = TestProbe[Any]()
+    val connectionInfo = ConnectionInfo(NodeAddress.fromParts("1.2.3.4", 9735).get, peerProbe.ref.toClassic, Init(Alice.nodeParams.features.initFeatures()), Init(Bob.nodeParams.features.initFeatures()))
+
+    // approve and continue single funded open channel
+    testKit.system.eventStream ! EventStream.Publish(OpenChannelReceived(peerProbe.ref.toClassic, Left(openChannel), ChannelTypes.Standard(), localParams, connectionInfo))
+    assert(peerProbe.expectMessageType[SpawnChannelNonInitiator] == SpawnChannelNonInitiator(Left(openChannel), ChannelConfig.standard, ChannelTypes.Standard(), localParams))
+
+    // fail request to open dual funded channel
+    testKit.system.eventStream ! EventStream.Publish(OpenChannelReceived(peerProbe.ref.toClassic, Right(openDualChannel), ChannelTypes.Standard(), localParams, connectionInfo))
+    peerProbe.expectMessageType[OutgoingMessage]
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <modules>
         <module>historical-gossip</module>
         <module>offline-commands</module>
+        <module>channel-interceptor</module>
     </modules>
 
     <description>Official eclair plugins</description>


### PR DESCRIPTION
This PR creates an example of a plugin that intercepts channel open messages sent to a node and continues the process or of accepting a valid request, or returns a failure message to the sender.

Depends on Eclair [PR# 2552](https://github.com/ACINQ/eclair/pull/2552).