### PR TITLE
Add tip jar plugin

### DIFF
--- a/bolt12-tip-jar/README.md
+++ b/bolt12-tip-jar/README.md
@@ -1,0 +1,17 @@
+# Bolt12 Tip Jar
+
+Plugin that creates a basic offer to receive tips.
+
+## Config
+
+```
+tip-jar {
+  description = "donation to eclair"
+  default-amount-msat = 100000000 // Amount to use if the invoice request does not specify an amount
+  max-final-expiry-delta = 1000 // How long (in blocks) the route to pay the invoice will be valid
+}
+```
+
+## API
+
+`tipjarshowoffer` will print the tip jar offer.

--- a/bolt12-tip-jar/pom.xml
+++ b/bolt12-tip-jar/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fr.acinq.eclair</groupId>
+        <artifactId>eclair-plugins_2.13</artifactId>
+        <version>0.8.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>bolt12-tip-jar</artifactId>
+    <packaging>jar</packaging>
+    <name>bolt12-tip-jar</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Main-Class>fr.acinq.eclair.plugins.tipjar.TipJarPlugin</Main-Class>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-core_${scala.version.short}</artifactId>
+            <version>${eclair.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-node_${scala.version.short}</artifactId>
+            <version>${eclair.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- TESTS -->
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-actor-testkit-typed_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-core_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/bolt12-tip-jar/pom.xml
+++ b/bolt12-tip-jar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair-plugins_2.13</artifactId>
-        <version>0.8.1-SNAPSHOT</version>
+        <version>0.9.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>bolt12-tip-jar</artifactId>

--- a/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/ApiHandlers.scala
+++ b/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/ApiHandlers.scala
@@ -23,6 +23,7 @@ object ApiHandlers {
 
   def registerRoutes(kit: TipJarKit, eclairDirectives: EclairDirectives): Route = {
     import eclairDirectives._
+    import fr.acinq.eclair.api.serde.JsonSupport.{formats, marshaller, serialization}
 
     val showOffer: Route = postRequest("tipjarshowoffer") { implicit t =>
       complete(kit.offer.toString)

--- a/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/ApiHandlers.scala
+++ b/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/ApiHandlers.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.tipjar
+
+import akka.http.scaladsl.server.Route
+import fr.acinq.eclair.api.directives.EclairDirectives
+
+object ApiHandlers {
+
+  def registerRoutes(kit: TipJarKit, eclairDirectives: EclairDirectives): Route = {
+    import eclairDirectives._
+
+    val showOffer: Route = postRequest("tipjarshowoffer") { implicit t =>
+      complete(kit.offer.toString)
+    }
+
+    showOffer
+  }
+
+}

--- a/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/TipJarHandler.scala
+++ b/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/TipJarHandler.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.tipjar
+
+import akka.actor.typed.Behavior
+import akka.actor.typed.scaladsl.Behaviors
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.eclair.offer.OfferManager
+import fr.acinq.eclair.offer.OfferManager.HandlerCommand
+import fr.acinq.eclair.offer.OfferManager.InvoiceRequestActor.ApproveRequest
+import fr.acinq.eclair.offer.OfferManager.PaymentActor.AcceptPayment
+import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivingRoute
+import fr.acinq.eclair.{CltvExpiryDelta, Feature, Features, MilliSatoshi}
+import scodec.bits.ByteVector
+
+object TipJarHandler {
+
+  def apply(nodeId: PublicKey, defaultAmount: MilliSatoshi, maxFinalExpiryDelta: CltvExpiryDelta,  features: Features[Feature]): Behavior[HandlerCommand] = {
+    Behaviors.receiveMessage {
+      case OfferManager.HandleInvoiceRequest(replyTo, invoiceRequest) =>
+        replyTo ! ApproveRequest(invoiceRequest.amount.getOrElse(defaultAmount), Seq(ReceivingRoute(Seq(nodeId), maxFinalExpiryDelta)), features, ByteVector.empty)
+        Behaviors.same
+      case OfferManager.HandlePayment(replyTo, _, _) =>
+        replyTo ! AcceptPayment()
+        Behaviors.same
+    }
+  }
+}

--- a/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/TipJarHandler.scala
+++ b/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/TipJarHandler.scala
@@ -19,20 +19,19 @@ package fr.acinq.eclair.plugins.tipjar
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
-import fr.acinq.eclair.offer.OfferManager
-import fr.acinq.eclair.offer.OfferManager.HandlerCommand
-import fr.acinq.eclair.offer.OfferManager.InvoiceRequestActor.ApproveRequest
-import fr.acinq.eclair.offer.OfferManager.PaymentActor.AcceptPayment
+import fr.acinq.eclair.payment.offer.OfferManager
+import fr.acinq.eclair.payment.offer.OfferManager.HandlerCommand
+import fr.acinq.eclair.payment.offer.OfferManager.InvoiceRequestActor.ApproveRequest
+import fr.acinq.eclair.payment.offer.OfferManager.PaymentActor.AcceptPayment
 import fr.acinq.eclair.payment.receive.MultiPartHandler.ReceivingRoute
-import fr.acinq.eclair.{CltvExpiryDelta, Feature, Features, MilliSatoshi}
-import scodec.bits.ByteVector
+import fr.acinq.eclair.{CltvExpiryDelta, MilliSatoshi}
 
 object TipJarHandler {
 
-  def apply(nodeId: PublicKey, defaultAmount: MilliSatoshi, maxFinalExpiryDelta: CltvExpiryDelta,  features: Features[Feature]): Behavior[HandlerCommand] = {
+  def apply(nodeId: PublicKey, defaultAmount: MilliSatoshi, maxFinalExpiryDelta: CltvExpiryDelta): Behavior[HandlerCommand] = {
     Behaviors.receiveMessage {
       case OfferManager.HandleInvoiceRequest(replyTo, invoiceRequest) =>
-        replyTo ! ApproveRequest(invoiceRequest.amount.getOrElse(defaultAmount), Seq(ReceivingRoute(Seq(nodeId), maxFinalExpiryDelta)), features, ByteVector.empty)
+        replyTo ! ApproveRequest(invoiceRequest.amount.getOrElse(defaultAmount), Seq(ReceivingRoute(Seq(nodeId), maxFinalExpiryDelta)), None)
         Behaviors.same
       case OfferManager.HandlePayment(replyTo, _, _) =>
         replyTo ! AcceptPayment()

--- a/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/TipJarPlugin.scala
+++ b/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/TipJarPlugin.scala
@@ -22,8 +22,8 @@ import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
 import akka.actor.typed.{ActorRef, SupervisorStrategy}
 import akka.http.scaladsl.server.Route
 import fr.acinq.eclair.api.directives.EclairDirectives
-import fr.acinq.eclair.offer.OfferManager
-import fr.acinq.eclair.offer.OfferManager.RegisterOffer
+import fr.acinq.eclair.payment.offer.OfferManager
+import fr.acinq.eclair.payment.offer.OfferManager.RegisterOffer
 import fr.acinq.eclair.wire.protocol.OfferTypes.Offer
 import fr.acinq.eclair.{CltvExpiryDelta, Features, Kit, MilliSatoshi, NodeParams, Plugin, PluginParams, RouteProvider, Setup}
 import grizzled.slf4j.Logging
@@ -45,7 +45,7 @@ class TipJarPlugin extends Plugin with RouteProvider with Logging {
   }
 
   override def onKit(kit: Kit): Unit = {
-    val tipJarHandler = kit.system.spawn(Behaviors.supervise(TipJarHandler(kit.nodeParams.nodeId, config.defaultAmount, config.maxFinalExpiryDelta, kit.nodeParams.features.bolt12Features().unscoped())).onFailure(SupervisorStrategy.restart), "tip-jar-handler")
+    val tipJarHandler = kit.system.spawn(Behaviors.supervise(TipJarHandler(kit.nodeParams.nodeId, config.defaultAmount, config.maxFinalExpiryDelta)).onFailure(SupervisorStrategy.restart), "tip-jar-handler")
     val offer = Offer(None, config.offerDescription, kit.nodeParams.nodeId, Features.empty, kit.nodeParams.chainHash)
     kit.offerManager ! RegisterOffer(offer, kit.nodeParams.privateKey, None, tipJarHandler)
     pluginKit = TipJarKit(kit.nodeParams, offer, kit.system, tipJarHandler)

--- a/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/TipJarPlugin.scala
+++ b/bolt12-tip-jar/src/main/scala/fr/acinq/eclair/plugins/tipjar/TipJarPlugin.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.tipjar
+
+import akka.actor.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter.ClassicActorSystemOps
+import akka.actor.typed.{ActorRef, SupervisorStrategy}
+import akka.http.scaladsl.server.Route
+import fr.acinq.eclair.api.directives.EclairDirectives
+import fr.acinq.eclair.offer.OfferManager
+import fr.acinq.eclair.offer.OfferManager.RegisterOffer
+import fr.acinq.eclair.wire.protocol.OfferTypes.Offer
+import fr.acinq.eclair.{CltvExpiryDelta, Features, Kit, MilliSatoshi, NodeParams, Plugin, PluginParams, RouteProvider, Setup}
+import grizzled.slf4j.Logging
+
+class TipJarPlugin extends Plugin with RouteProvider with Logging {
+
+  private var pluginKit: TipJarKit = _
+  private var config: TipJarConfig = _
+
+  override def params: PluginParams = new PluginParams {
+    override def name: String = "TipJarPlugin"
+  }
+
+  override def onSetup(setup: Setup): Unit = {
+    config = TipJarConfig(
+      setup.config.getString("tip-jar.description"),
+      MilliSatoshi(setup.config.getLong("tip-jar.default-amount-msat")),
+      CltvExpiryDelta(setup.config.getInt("tip-jar.max-final-expiry-delta")))
+  }
+
+  override def onKit(kit: Kit): Unit = {
+    val tipJarHandler = kit.system.spawn(Behaviors.supervise(TipJarHandler(kit.nodeParams.nodeId, config.defaultAmount, config.maxFinalExpiryDelta, kit.nodeParams.features.bolt12Features().unscoped())).onFailure(SupervisorStrategy.restart), "tip-jar-handler")
+    val offer = Offer(None, config.offerDescription, kit.nodeParams.nodeId, Features.empty, kit.nodeParams.chainHash)
+    kit.offerManager ! RegisterOffer(offer, kit.nodeParams.privateKey, None, tipJarHandler)
+    pluginKit = TipJarKit(kit.nodeParams, offer, kit.system, tipJarHandler)
+  }
+
+  override def route(eclairDirectives: EclairDirectives): Route = ApiHandlers.registerRoutes(pluginKit, eclairDirectives)
+
+}
+
+case class TipJarConfig(offerDescription: String, defaultAmount: MilliSatoshi, maxFinalExpiryDelta: CltvExpiryDelta)
+
+case class TipJarKit(nodeParams: NodeParams, offer: Offer, system: ActorSystem, tipJarHandler: ActorRef[OfferManager.HandlerCommand])

--- a/bolt12-tip-jar/src/test/scala/fr/acinq/eclair/plugins/tipjar/TipJarHandlerSpec.scala
+++ b/bolt12-tip-jar/src/test/scala/fr/acinq/eclair/plugins/tipjar/TipJarHandlerSpec.scala
@@ -18,21 +18,18 @@ package fr.acinq.eclair.plugins.tipjar
 
 import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
 import fr.acinq.bitcoin.scalacompat.ByteVector64
-import fr.acinq.eclair.FeatureSupport.Optional
-import fr.acinq.eclair.Features.BasicMultiPartPayment
-import fr.acinq.eclair.offer.OfferManager.InvoiceRequestActor.ApproveRequest
-import fr.acinq.eclair.offer.OfferManager.PaymentActor.AcceptPayment
-import fr.acinq.eclair.offer.OfferManager.{HandleInvoiceRequest, HandlePayment, InvoiceRequestActor, PaymentActor}
+import fr.acinq.eclair.payment.offer.OfferManager.InvoiceRequestActor.ApproveRequest
+import fr.acinq.eclair.payment.offer.OfferManager.PaymentActor.AcceptPayment
+import fr.acinq.eclair.payment.offer.OfferManager.{HandleInvoiceRequest, HandlePayment, InvoiceRequestActor, PaymentActor}
 import fr.acinq.eclair.wire.protocol.OfferTypes.{InvoiceRequest, InvoiceRequestChain, InvoiceRequestMetadata, InvoiceRequestPayerId, Offer, Signature}
 import fr.acinq.eclair.wire.protocol.TlvStream
 import fr.acinq.eclair.{CltvExpiryDelta, Features, MilliSatoshiLong, TestConstants, randomBytes32, randomKey}
 import org.scalatest.funsuite.AnyFunSuiteLike
-import scodec.bits.ByteVector
 
 class TipJarHandlerSpec extends ScalaTestWithActorTestKit with AnyFunSuiteLike {
   test("handle invoice request") {
     val nodeParams = TestConstants.Alice.nodeParams
-    val handler = testKit.spawn(TipJarHandler(nodeParams.nodeId, 100_000_000 msat, CltvExpiryDelta(1000), Features(BasicMultiPartPayment -> Optional)))
+    val handler = testKit.spawn(TipJarHandler(nodeParams.nodeId, 100_000_000 msat, CltvExpiryDelta(1000)))
 
     val probe = TestProbe[InvoiceRequestActor.Command]()
 
@@ -42,16 +39,15 @@ class TipJarHandlerSpec extends ScalaTestWithActorTestKit with AnyFunSuiteLike {
 
     val approve = probe.expectMessageType[ApproveRequest]
     assert(approve.amount == 100_000_000.msat)
-    assert(approve.features == Features(BasicMultiPartPayment -> Optional))
   }
 
   test("handle payment"){
     val nodeParams = TestConstants.Alice.nodeParams
-    val handler = testKit.spawn(TipJarHandler(nodeParams.nodeId, 100_000_000 msat, CltvExpiryDelta(1000), Features(BasicMultiPartPayment -> Optional)))
+    val handler = testKit.spawn(TipJarHandler(nodeParams.nodeId, 100_000_000 msat, CltvExpiryDelta(1000)))
 
     val probe = TestProbe[PaymentActor.Command]()
 
-    handler ! HandlePayment(probe.ref, randomBytes32(), ByteVector.empty)
+    handler ! HandlePayment(probe.ref, randomBytes32(), None)
 
     probe.expectMessage(AcceptPayment())
   }

--- a/bolt12-tip-jar/src/test/scala/fr/acinq/eclair/plugins/tipjar/TipJarHandlerSpec.scala
+++ b/bolt12-tip-jar/src/test/scala/fr/acinq/eclair/plugins/tipjar/TipJarHandlerSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.tipjar
+
+import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
+import fr.acinq.bitcoin.scalacompat.ByteVector64
+import fr.acinq.eclair.FeatureSupport.Optional
+import fr.acinq.eclair.Features.BasicMultiPartPayment
+import fr.acinq.eclair.offer.OfferManager.InvoiceRequestActor.ApproveRequest
+import fr.acinq.eclair.offer.OfferManager.PaymentActor.AcceptPayment
+import fr.acinq.eclair.offer.OfferManager.{HandleInvoiceRequest, HandlePayment, InvoiceRequestActor, PaymentActor}
+import fr.acinq.eclair.wire.protocol.OfferTypes.{InvoiceRequest, InvoiceRequestChain, InvoiceRequestMetadata, InvoiceRequestPayerId, Offer, Signature}
+import fr.acinq.eclair.wire.protocol.TlvStream
+import fr.acinq.eclair.{CltvExpiryDelta, Features, MilliSatoshiLong, TestConstants, randomBytes32, randomKey}
+import org.scalatest.funsuite.AnyFunSuiteLike
+import scodec.bits.ByteVector
+
+class TipJarHandlerSpec extends ScalaTestWithActorTestKit with AnyFunSuiteLike {
+  test("handle invoice request") {
+    val nodeParams = TestConstants.Alice.nodeParams
+    val handler = testKit.spawn(TipJarHandler(nodeParams.nodeId, 100_000_000 msat, CltvExpiryDelta(1000), Features(BasicMultiPartPayment -> Optional)))
+
+    val probe = TestProbe[InvoiceRequestActor.Command]()
+
+    val offer = Offer(None, "test tip jar", nodeParams.nodeId, Features.empty, nodeParams.chainHash)
+    val invoiceRequest = InvoiceRequest(TlvStream(offer.records.records ++ Set(InvoiceRequestMetadata(randomBytes32()), InvoiceRequestChain(nodeParams.chainHash), InvoiceRequestPayerId(randomKey().publicKey), Signature(ByteVector64.Zeroes))))
+    handler ! HandleInvoiceRequest(probe.ref, invoiceRequest)
+
+    val approve = probe.expectMessageType[ApproveRequest]
+    assert(approve.amount == 100_000_000.msat)
+    assert(approve.features == Features(BasicMultiPartPayment -> Optional))
+  }
+
+  test("handle payment"){
+    val nodeParams = TestConstants.Alice.nodeParams
+    val handler = testKit.spawn(TipJarHandler(nodeParams.nodeId, 100_000_000 msat, CltvExpiryDelta(1000), Features(BasicMultiPartPayment -> Optional)))
+
+    val probe = TestProbe[PaymentActor.Command]()
+
+    handler ! HandlePayment(probe.ref, randomBytes32(), ByteVector.empty)
+
+    probe.expectMessage(AcceptPayment())
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <modules>
         <module>historical-gossip</module>
         <module>offline-commands</module>
+        <module>bolt12-tip-jar</module>
     </modules>
 
     <description>Official eclair plugins</description>


### PR DESCRIPTION
Very basic plugin demonstrating how to handle offers from the merchant's side. This plugin just creates a simple "tip" offer and accept all payments.