### PR TITLE
Add channel funding plugin

### DIFF
--- a/channel-funding/README.md
+++ b/channel-funding/README.md
@@ -1,4 +1,4 @@
-# Channel Interceptor plugin
+# Channel Funding plugin
 
 This plugin provides an example of how to accept or reject `open_channel` messages received from remote peers based on a custom configuration file `channel_funding.conf`.
 Documentation for the various configuration options can be found in the [default configuration file](/src/main/resources/reference.conf).

--- a/channel-funding/README.md
+++ b/channel-funding/README.md
@@ -1,0 +1,22 @@
+# Channel Interceptor plugin
+
+This plugin provides an example of how to accept or reject `open_channel` messages received from remote peers based on a custom configuration file `channel_funding.conf`.
+Documentation for the various configuration options can be found in the [default configuration file](/src/main/resources/reference.conf).
+
+Disclaimer: this plugin is for demonstration purposes only, node operators should fork this plugin and implement whatever policies make sense for their node. 
+
+## Build
+
+To build this plugin, run the following command in this directory:
+
+```sh
+mvn package
+```
+
+## Run
+
+To run eclair with this plugin, start eclair with the following command:
+
+```sh
+eclair-node-<version>/bin/eclair-node.sh <path-to-plugin-jar>/channel-funding-plugin-<version>.jar
+```

--- a/channel-funding/pom.xml
+++ b/channel-funding/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>fr.acinq.eclair</groupId>
+        <artifactId>eclair-plugins_2.13</artifactId>
+        <version>0.9.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>channel-funding-plugin</artifactId>
+    <packaging>jar</packaging>
+    <name>channel-funding-plugin</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <configuration>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <manifestEntries>
+                                <Main-Class>fr.acinq.eclair.plugins.channelfunding.ChannelFundingPlugin</Main-Class>
+                            </manifestEntries>
+                        </transformer>
+                    </transformers>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>${scala.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-core_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-node_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- TESTS -->
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-actor-testkit-typed_${scala.version.short}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>fr.acinq.eclair</groupId>
+            <artifactId>eclair-core_${scala.version.short}</artifactId>
+            <version>${project.version}</version>
+            <classifier>tests</classifier>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/channel-funding/src/main/resources/reference.conf
+++ b/channel-funding/src/main/resources/reference.conf
@@ -1,0 +1,23 @@
+channel-funding {
+  // When a remote node tries to open a channel with us, we only accept it if they meet the requirements below.
+  remote-node-requirements {
+    // If the remote node is in the following whitelist, we don't check other requirements and accept their channel.
+    peer-whitelist = [
+      "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+    ]
+    // If the remote node doesn't have enough public channels, we reject their request.
+    min-active-channels = 10
+    // If the remote node's doesn't have enough funds locked into existing public channels, we reject their request.
+    min-total-capacity-sat = 2000000
+    // If the remote node cannot be found in the public network graph, we reject their request.
+    allow-private-nodes = true
+  }
+  // Funding amount we contribute to a dual-funded channel initiated by a remote node.
+  dual-funding-liquidity-policy {
+    peer-whitelist = [
+      "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+    ]
+    // Funding amount we will contribute if a remote node from the peer-whitelist opens a dual-funded channel with us.
+    local-funding-amount-sat = 250000
+  }
+}

--- a/channel-funding/src/main/resources/reference.conf
+++ b/channel-funding/src/main/resources/reference.conf
@@ -10,7 +10,7 @@ channel-funding {
     // If the remote node's doesn't have enough funds locked into existing public channels, we reject their request.
     min-total-capacity-sat = 2000000
     // If the remote node cannot be found in the public network graph, we reject their request.
-    allow-private-nodes = true
+    reject-private-nodes = true
   }
   // Funding amount we contribute to a dual-funded channel initiated by a remote node.
   dual-funding-liquidity-policy {

--- a/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/ChannelFundingPlugin.scala
+++ b/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/ChannelFundingPlugin.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.channelfunding
+
+import akka.actor.ActorSystem
+import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.scaladsl.adapter.{ClassicActorRefOps, ClassicActorSystemOps}
+import akka.actor.typed.{ActorRef, SupervisorStrategy}
+import com.typesafe.config.ConfigFactory
+import fr.acinq.eclair.{InterceptOpenChannelCommand, InterceptOpenChannelPlugin, Kit, NodeParams, Plugin, PluginParams, Setup}
+import grizzled.slf4j.Logging
+
+import java.io.File
+
+/**
+ * Intercept open_channel messages received by the node and respond by continuing the process of accepting the request,
+ * potentially with different local parameters, or failing the request.
+ */
+class ChannelFundingPlugin extends Plugin with Logging {
+  private var pluginKit: OpenChannelInterceptorKit = _
+  private var config: ChannelFundingPluginConfig = _
+
+  override def params: PluginParams = new InterceptOpenChannelPlugin {
+    // @formatter:off
+    override def name: String = "ChannelFundingPlugin"
+    // @formatter:on
+    override def openChannelInterceptor: ActorRef[InterceptOpenChannelCommand] = pluginKit.openChannelInterceptor
+  }
+
+  override def onSetup(setup: Setup): Unit = {
+    config = loadConfiguration(setup.datadir)
+  }
+
+  override def onKit(kit: Kit): Unit = {
+    val openChannelInterceptor = kit.system.spawnAnonymous(Behaviors.supervise(OpenChannelInterceptor(config, kit.router.toTyped)).onFailure(SupervisorStrategy.restart))
+    pluginKit = OpenChannelInterceptorKit(kit.nodeParams, kit.system, openChannelInterceptor)
+  }
+
+  /**
+   * Order of precedence for the configuration parameters:
+   * 1) Java environment variables (-D...)
+   * 2) Configuration file channel_funding.conf
+   * 3) Default values in reference.conf
+   */
+  private def loadConfiguration(datadir: File): ChannelFundingPluginConfig = {
+    val config = ConfigFactory.systemProperties()
+      .withFallback(ConfigFactory.parseFile(new File(datadir, "channel_funding.conf")))
+      .withFallback(ConfigFactory.load())
+      .resolve()
+    ChannelFundingPluginConfig(config)
+  }
+}
+
+case class OpenChannelInterceptorKit(nodeParams: NodeParams, system: ActorSystem, openChannelInterceptor: ActorRef[InterceptOpenChannelCommand])

--- a/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/ChannelFundingPluginConfig.scala
+++ b/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/ChannelFundingPluginConfig.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.channelfunding
+
+import com.typesafe.config.Config
+import fr.acinq.bitcoin.scalacompat.Crypto.PublicKey
+import fr.acinq.bitcoin.scalacompat.Satoshi
+import scodec.bits.ByteVector
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+/**
+ * @param whitelist         nodes from this whitelist will be allowed even if they don't meet requirements.
+ * @param minActiveChannels minimum number of public channels the remote node must have.
+ * @param minTotalCapacity  minimum total capacity of existing public channels the remote node must have.
+ * @param allowPrivateNodes if true, we allow channels from private nodes (who have no public channels yet).
+ */
+case class RemoteNodeRequirements(whitelist: Set[PublicKey], minActiveChannels: Int, minTotalCapacity: Satoshi, allowPrivateNodes: Boolean) {
+  def isWhitelisted(nodeId: PublicKey): Boolean = whitelist.contains(nodeId)
+}
+
+case class DualFundingLiquidityPolicy(whitelist: Set[PublicKey], fundingAmount: Satoshi) {
+  def fundingAmountFor(nodeId: PublicKey): Option[Satoshi] = if (whitelist.contains(nodeId)) Some(fundingAmount) else None
+}
+
+case class ChannelFundingPluginConfig(remoteNodeRequirements: RemoteNodeRequirements, fundingPolicy: DualFundingLiquidityPolicy)
+
+object ChannelFundingPluginConfig {
+  def apply(config: Config): ChannelFundingPluginConfig = {
+    ChannelFundingPluginConfig(
+      RemoteNodeRequirements(
+        whitelist = config.getStringList("channel-funding.remote-node-requirements.peer-whitelist").asScala.map(s => PublicKey(ByteVector.fromValidHex(s), checkValid = true)).toSet,
+        minActiveChannels = config.getInt("channel-funding.remote-node-requirements.min-active-channels"),
+        minTotalCapacity = Satoshi(config.getLong("channel-funding.remote-node-requirements.min-total-capacity-sat")),
+        allowPrivateNodes = config.getBoolean("channel-funding.remote-node-requirements.allow-private-nodes"),
+      ),
+      DualFundingLiquidityPolicy(
+        whitelist = config.getStringList("channel-funding.dual-funding-liquidity-policy.peer-whitelist").asScala.map(s => PublicKey(ByteVector.fromValidHex(s), checkValid = true)).toSet,
+        fundingAmount = Satoshi(config.getLong("channel-funding.dual-funding-liquidity-policy.local-funding-amount-sat")),
+      )
+    )
+  }
+}

--- a/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/ChannelFundingPluginConfig.scala
+++ b/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/ChannelFundingPluginConfig.scala
@@ -24,12 +24,12 @@ import scodec.bits.ByteVector
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 /**
- * @param whitelist         nodes from this whitelist will be allowed even if they don't meet requirements.
- * @param minActiveChannels minimum number of public channels the remote node must have.
- * @param minTotalCapacity  minimum total capacity of existing public channels the remote node must have.
- * @param allowPrivateNodes if true, we allow channels from private nodes (who have no public channels yet).
+ * @param whitelist          nodes from this whitelist will be allowed even if they don't meet requirements.
+ * @param minActiveChannels  minimum number of public channels the remote node must have.
+ * @param minTotalCapacity   minimum total capacity of existing public channels the remote node must have.
+ * @param rejectPrivateNodes if true, we reject channels from private nodes (who have no public channels yet).
  */
-case class RemoteNodeRequirements(whitelist: Set[PublicKey], minActiveChannels: Int, minTotalCapacity: Satoshi, allowPrivateNodes: Boolean) {
+case class RemoteNodeRequirements(whitelist: Set[PublicKey], minActiveChannels: Int, minTotalCapacity: Satoshi, rejectPrivateNodes: Boolean) {
   def isWhitelisted(nodeId: PublicKey): Boolean = whitelist.contains(nodeId)
 }
 
@@ -46,7 +46,7 @@ object ChannelFundingPluginConfig {
         whitelist = config.getStringList("channel-funding.remote-node-requirements.peer-whitelist").asScala.map(s => PublicKey(ByteVector.fromValidHex(s), checkValid = true)).toSet,
         minActiveChannels = config.getInt("channel-funding.remote-node-requirements.min-active-channels"),
         minTotalCapacity = Satoshi(config.getLong("channel-funding.remote-node-requirements.min-total-capacity-sat")),
-        allowPrivateNodes = config.getBoolean("channel-funding.remote-node-requirements.allow-private-nodes"),
+        rejectPrivateNodes = config.getBoolean("channel-funding.remote-node-requirements.reject-private-nodes"),
       ),
       DualFundingLiquidityPolicy(
         whitelist = config.getStringList("channel-funding.dual-funding-liquidity-policy.peer-whitelist").asScala.map(s => PublicKey(ByteVector.fromValidHex(s), checkValid = true)).toSet,

--- a/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/OpenChannelInterceptor.scala
+++ b/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/OpenChannelInterceptor.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.channelfunding
+
+import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
+import akka.actor.typed.{ActorRef, Behavior}
+import fr.acinq.eclair.router.Router
+import fr.acinq.eclair.router.Router.{GetNode, PublicNode, UnknownNode}
+import fr.acinq.eclair.wire.protocol.Error
+import fr.acinq.eclair.{AcceptOpenChannel, InterceptOpenChannelCommand, InterceptOpenChannelReceived, RejectOpenChannel}
+
+/**
+ * Intercept OpenChannel and OpenDualFundedChannel messages received by the node. Respond to the peer that received the
+ * request with AcceptOpenChannel to continue the open channel process, optionally with modified default parameters, or
+ * fail the request by responding to the initiator with RejectOpenChannel and an Error message.
+ *
+ * This example plugin decides how much funds (if any) the non-initiator should put into a dual-funded channel. It also
+ * demonstrates how to reject requests from nodes with less than a minimum amount of total capacity or too few public
+ * channels.
+ */
+object OpenChannelInterceptor {
+  private case class WrappedGetNodeResponse(interceptOpenChannelReceived: InterceptOpenChannelReceived, response: Router.GetNodeResponse) extends InterceptOpenChannelCommand
+
+  def apply(config: ChannelFundingPluginConfig, router: ActorRef[Any]): Behavior[InterceptOpenChannelCommand] = {
+    Behaviors.setup {
+      context => new OpenChannelInterceptor(config, router, context).start()
+    }
+  }
+
+}
+
+class OpenChannelInterceptor(config: ChannelFundingPluginConfig, router: ActorRef[Any], context: ActorContext[InterceptOpenChannelCommand]) {
+
+  import OpenChannelInterceptor._
+
+  private def start(): Behavior[InterceptOpenChannelCommand] = {
+    Behaviors.receiveMessage {
+      case o: InterceptOpenChannelReceived =>
+        if (config.remoteNodeRequirements.isWhitelisted(o.openChannelNonInitiator.remoteNodeId) || config.fundingPolicy.whitelist.contains(o.openChannelNonInitiator.remoteNodeId)) {
+          acceptOpenChannel(o)
+        } else {
+          // We check that the remote node meets our requirements.
+          val adapter = context.messageAdapter[Router.GetNodeResponse](nodeResponse => WrappedGetNodeResponse(o, nodeResponse))
+          router ! GetNode(adapter, o.openChannelNonInitiator.remoteNodeId)
+        }
+        Behaviors.same
+      case WrappedGetNodeResponse(o, PublicNode(_, activeChannels, _)) if activeChannels < config.remoteNodeRequirements.minActiveChannels =>
+        rejectOpenChannel(o, s"channel request rejected, remote node has less than ${config.remoteNodeRequirements.minActiveChannels} active channels")
+        Behaviors.same
+      case WrappedGetNodeResponse(o, PublicNode(_, _, totalCapacity)) if totalCapacity < config.remoteNodeRequirements.minTotalCapacity =>
+        rejectOpenChannel(o, s"channel request rejected, remote node has less than ${config.remoteNodeRequirements.minTotalCapacity} of public total capacity")
+        Behaviors.same
+      case WrappedGetNodeResponse(o, UnknownNode(_)) =>
+        if (!config.remoteNodeRequirements.allowPrivateNodes) {
+          rejectOpenChannel(o, "channel request rejected, remote node has no public channels")
+        } else {
+          acceptOpenChannel(o)
+        }
+        Behaviors.same
+      case WrappedGetNodeResponse(o, PublicNode(_, _, _)) =>
+        acceptOpenChannel(o)
+        Behaviors.same
+    }
+  }
+
+  private def acceptOpenChannel(o: InterceptOpenChannelReceived): Unit = {
+    o.replyTo ! AcceptOpenChannel(o.temporaryChannelId, o.defaultParams, config.fundingPolicy.fundingAmountFor(o.openChannelNonInitiator.remoteNodeId))
+  }
+
+  private def rejectOpenChannel(o: InterceptOpenChannelReceived, error: String): Unit = {
+    o.replyTo ! RejectOpenChannel(o.temporaryChannelId, Error(o.temporaryChannelId, error))
+  }
+}

--- a/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/OpenChannelInterceptor.scala
+++ b/channel-funding/src/main/scala/fr/acinq/eclair/plugins/channelfunding/OpenChannelInterceptor.scala
@@ -65,7 +65,7 @@ class OpenChannelInterceptor(config: ChannelFundingPluginConfig, router: ActorRe
         rejectOpenChannel(o, s"channel request rejected, remote node has less than ${config.remoteNodeRequirements.minTotalCapacity} of public total capacity")
         Behaviors.same
       case WrappedGetNodeResponse(o, UnknownNode(_)) =>
-        if (!config.remoteNodeRequirements.allowPrivateNodes) {
+        if (config.remoteNodeRequirements.rejectPrivateNodes) {
           rejectOpenChannel(o, "channel request rejected, remote node has no public channels")
         } else {
           acceptOpenChannel(o)

--- a/channel-funding/src/test/scala/fr/acinq/eclair/plugins/channelfunding/OpenChannelInterceptorSpec.scala
+++ b/channel-funding/src/test/scala/fr/acinq/eclair/plugins/channelfunding/OpenChannelInterceptorSpec.scala
@@ -48,7 +48,7 @@ class OpenChannelInterceptorSpec extends ScalaTestWithActorTestKit(ConfigFactory
         whitelist = Set(whitelistedRemoteNodeId),
         minActiveChannels = 2,
         minTotalCapacity = 10_000 sat,
-        allowPrivateNodes = !test.tags.contains("no-private-peers")
+        rejectPrivateNodes = test.tags.contains("no-private-peers")
       ),
       DualFundingLiquidityPolicy(
         whitelist = Set(whitelistedRemoteNodeId),

--- a/channel-funding/src/test/scala/fr/acinq/eclair/plugins/channelfunding/OpenChannelInterceptorSpec.scala
+++ b/channel-funding/src/test/scala/fr/acinq/eclair/plugins/channelfunding/OpenChannelInterceptorSpec.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2023 ACINQ SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fr.acinq.eclair.plugins.channelfunding
+
+import akka.actor.testkit.typed.scaladsl.{ScalaTestWithActorTestKit, TestProbe}
+import akka.actor.typed.ActorRef
+import com.typesafe.config.ConfigFactory
+import fr.acinq.bitcoin.scalacompat.SatoshiLong
+import fr.acinq.eclair.io.OpenChannelInterceptor.{DefaultParams, OpenChannelNonInitiator}
+import fr.acinq.eclair.io.PeerSpec.{createOpenChannelMessage, createOpenDualFundedChannelMessage}
+import fr.acinq.eclair.router.Router.{GetNode, PublicNode, UnknownNode}
+import fr.acinq.eclair.wire.protocol._
+import fr.acinq.eclair.{AcceptOpenChannel, CltvExpiryDelta, Features, InterceptOpenChannelCommand, InterceptOpenChannelReceived, InterceptOpenChannelResponse, MilliSatoshiLong, RejectOpenChannel, TimestampSecondLong, randomBytes64, randomKey}
+import org.scalatest.funsuite.FixtureAnyFunSuiteLike
+import org.scalatest.{Outcome, Tag}
+
+import scala.concurrent.duration.DurationInt
+
+class OpenChannelInterceptorSpec extends ScalaTestWithActorTestKit(ConfigFactory.load("application")) with FixtureAnyFunSuiteLike {
+  val remoteNodeId = randomKey().publicKey
+  val whitelistedRemoteNodeId = randomKey().publicKey
+  val peerAddress = NodeAddress.fromParts("127.0.0.1", 9735).get
+  val defaultParams = DefaultParams(100 sat, 100000 msat, 100 msat, CltvExpiryDelta(288), 10)
+  val openChannel = OpenChannelNonInitiator(remoteNodeId, Left(createOpenChannelMessage()), Features.empty, Features.empty, TestProbe[Any]().ref, peerAddress)
+  val announcement = NodeAnnouncement(randomBytes64(), Features.empty, 1 unixsec, remoteNodeId, Color(100.toByte, 200.toByte, 300.toByte), "node-alias", NodeAddress.fromParts("1.2.3.4", 42000).get :: Nil)
+
+  case class FixtureParam(router: TestProbe[Any], peer: TestProbe[InterceptOpenChannelResponse], openChannelInterceptor: ActorRef[InterceptOpenChannelCommand])
+
+  override def withFixture(test: OneArgTest): Outcome = {
+    val router = TestProbe[Any]()
+    val peer = TestProbe[InterceptOpenChannelResponse]()
+    val config = ChannelFundingPluginConfig(
+      RemoteNodeRequirements(
+        whitelist = Set(whitelistedRemoteNodeId),
+        minActiveChannels = 2,
+        minTotalCapacity = 10_000 sat,
+        allowPrivateNodes = !test.tags.contains("no-private-peers")
+      ),
+      DualFundingLiquidityPolicy(
+        whitelist = Set(whitelistedRemoteNodeId),
+        fundingAmount = 200_000 sat,
+      )
+    )
+    val openChannelInterceptor = testKit.spawn(OpenChannelInterceptor(config, router.ref))
+    withFixture(test.toNoArgTest(FixtureParam(router, peer, openChannelInterceptor)))
+  }
+
+  test("approve channel requests") { f =>
+    import f._
+
+    // request from public peer
+    openChannelInterceptor ! InterceptOpenChannelReceived(peer.ref, openChannel, defaultParams)
+    router.expectMessageType[GetNode].replyTo ! PublicNode(announcement, 2, 10000 sat)
+    assert(peer.expectMessageType[AcceptOpenChannel] == AcceptOpenChannel(openChannel.temporaryChannelId, defaultParams, None))
+
+    // request from private peer
+    openChannelInterceptor ! InterceptOpenChannelReceived(peer.ref, openChannel, defaultParams)
+    router.expectMessageType[GetNode].replyTo ! UnknownNode(remoteNodeId)
+    assert(peer.expectMessageType[AcceptOpenChannel] == AcceptOpenChannel(openChannel.temporaryChannelId, defaultParams, None))
+  }
+
+  test("approve and contribute to dual-funded channel request") { f =>
+    import f._
+
+    val openChannelDualFunded = OpenChannelNonInitiator(whitelistedRemoteNodeId, Right(createOpenDualFundedChannelMessage()), Features.empty, Features.empty, TestProbe[Any]().ref, peerAddress)
+    openChannelInterceptor ! InterceptOpenChannelReceived(peer.ref, openChannelDualFunded, defaultParams)
+    router.expectNoMessage(100 millis) // we don't check requirements for whitelisted nodes
+    val accept = peer.expectMessageType[AcceptOpenChannel]
+    assert(accept.temporaryChannelId == openChannelDualFunded.temporaryChannelId)
+    assert(accept.localFundingAmount_opt.contains(200_000 sat))
+  }
+
+  test("reject channel requests", Tag("no-private-peers")) { f =>
+    import f._
+
+    // from public peer with too low capacity
+    openChannelInterceptor ! InterceptOpenChannelReceived(peer.ref, openChannel, defaultParams)
+    router.expectMessageType[GetNode].replyTo ! PublicNode(announcement, 2, 9999 sat)
+    assert(peer.expectMessageType[RejectOpenChannel].error.toAscii.contains("total capacity"))
+
+    // from public peer with too few channels
+    openChannelInterceptor ! InterceptOpenChannelReceived(peer.ref, openChannel, defaultParams)
+    router.expectMessageType[GetNode].replyTo ! PublicNode(announcement, 1, 10000 sat)
+    assert(peer.expectMessageType[RejectOpenChannel].error.toAscii.contains("active channels"))
+
+    // from private peer
+    openChannelInterceptor ! InterceptOpenChannelReceived(peer.ref, openChannel, defaultParams)
+    router.expectMessageType[GetNode].replyTo ! UnknownNode(remoteNodeId)
+    assert(peer.expectMessageType[RejectOpenChannel].error.toAscii.contains("no public channels"))
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <modules>
         <module>historical-gossip</module>
         <module>offline-commands</module>
+        <module>channel-funding</module>
     </modules>
 
     <description>Official eclair plugins</description>


### PR DESCRIPTION
Add a plugin showcasing how incoming channel requests can be intercepted to let node operators apply restrictions on what channels they accept.

This can also be used to leverage dual funding to make sure channels are immediately funded on both sides.

Co-authored with @remyers: I forked #4 to add the dual-funding part, based on https://github.com/ACINQ/eclair/pull/2829