### PR TITLE
Update build to use eclair snapshot

### DIFF
--- a/bolt12-tip-jar/pom.xml
+++ b/bolt12-tip-jar/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair-plugins_2.13</artifactId>
-        <version>0.12.0</version>
+        <version>0.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>bolt12-tip-jar</artifactId>

--- a/channel-funding/pom.xml
+++ b/channel-funding/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair-plugins_2.13</artifactId>
-        <version>0.12.0</version>
+        <version>0.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>channel-funding-plugin</artifactId>

--- a/historical-gossip/pom.xml
+++ b/historical-gossip/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair-plugins_2.13</artifactId>
-        <version>0.12.0</version>
+        <version>0.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>historical-gossip-plugin</artifactId>

--- a/offline-commands/pom.xml
+++ b/offline-commands/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fr.acinq.eclair</groupId>
         <artifactId>eclair-plugins_2.13</artifactId>
-        <version>0.12.0</version>
+        <version>0.13.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>offline-commands-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fr.acinq.eclair</groupId>
     <artifactId>eclair-plugins_2.13</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -54,7 +54,7 @@
         <scalatest.version>3.2.12</scalatest.version>
         <akka.version>2.6.20</akka.version>
         <akka.http.version>10.2.7</akka.http.version>
-        <eclair.version>0.12.0</eclair.version>
+        <eclair.version>0.13.0-SNAPSHOT</eclair.version>
     </properties>
 
     <build>


### PR DESCRIPTION
This is required for the CI to pass, since in the CI we checkout eclair and package it locally, thus using version `0.13.0-SNAPSHOT`.